### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: scala-sbt
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-17_14_49](https://github.com/che-samples/scala-sbt/assets/1271546/4839f276-11a3-4cb6-93f4-d8f435d5fac3)


Related issue: https://github.com/eclipse/che/issues/21985